### PR TITLE
Replace LaravelCollective forms with Spatie HTML builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Can work out the box with or without the following roles packages:
 |Seeded blocked types with ability to add own published seeds|
 |Seeded blocked items with ability to add own published seeds|
 |Softdeletes with easy to use restore and destroy interface|
-|Uses [laravelcollective/html](https://github.com/LaravelCollective/html) package for secure HTML forms|
+|Uses [spatie/laravel-html](https://github.com/spatie/laravel-html) package for secure HTML forms|
 |Uses [eklundkristoffer/seedster](https://github.com/eklundkristoffer/seedster) for optional default seeds|
 |Makes use of proper custom request classes structure|
 |Can use pagination if desired for dashboards|
@@ -61,7 +61,7 @@ Can work out the box with or without the following roles packages:
 
 #### Required Packages
 (included in this package)
-* [laravelcollective/html](https://packagist.org/packages/laravelcollective/html)
+* [spatie/laravel-html](https://packagist.org/packages/spatie/laravel-html)
 * [eklundkristoffer/seedster](https://github.com/eklundkristoffer/seedster)
 
 ### Installation Instructions
@@ -90,7 +90,7 @@ Register the package with laravel in `config/app.php` under `providers` with the
 
 ```php
     'providers' => [
-        Collective\Html\HtmlServiceProvider::class,
+        Spatie\Html\HtmlServiceProvider::class,
         jeremykenedy\LaravelBlocker\LaravelBlockerServiceProvider::class,
     ];
 ```
@@ -98,8 +98,7 @@ Register the package with laravel in `config/app.php` under `providers` with the
 In `config/app.php` section under `aliases` with the following:
 
 ```php
-    'Form' => Collective\Html\FormFacade::class,
-    'Html' => Collective\Html\HtmlFacade::class,
+    'Html' => Spatie\Html\HtmlFacade::class,
 ```
 
 3. Publish the packages views, config file, assets, and language files by running the following from your projects root folder:

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": "^7.3|^8.0",
         "eklundkristoffer/seedster": "^7.0|^8.0|^9.0",
-        "laravelcollective/html": "^6.4"
+        "spatie/laravel-html": "^2.0|^3.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/resources/views/forms/create-new.blade.php
+++ b/src/resources/views/forms/create-new.blade.php
@@ -1,17 +1,17 @@
-{!! Form::open([
-    'route' => 'laravelblocker::blocker.store',
-    'method' => 'POST',
-    'role' => 'form',
-    'class' => 'needs-validation'
-]) !!}
-    {!! csrf_field() !!}
+{{ html()->form('POST', route('laravelblocker::blocker.store'))
+        ->attribute('role', 'form')
+        ->class('needs-validation')
+        ->open() }}
+    @csrf
     @include('laravelblocker::forms.partials.item-type-select')
     @include('laravelblocker::forms.partials.item-value-input')
     @include('laravelblocker::forms.partials.item-blocked-user-select')
     @include('laravelblocker::forms.partials.item-note-input')
     <div class="row">
         <div class="col-sm-9 offset-sm-3">
-                {!! Form::button(trans('laravelblocker::laravelblocker.buttons.create-larger'), array('class' => 'btn btn-success btn-block margin-bottom-1 mb-1 float-right','type' => 'submit' )) !!}
+                {{ html()->button(trans('laravelblocker::laravelblocker.buttons.create-larger'))
+                        ->class('btn btn-success btn-block margin-bottom-1 mb-1 float-right')
+                        ->type('submit') }}
         </div>
     </div>
-{!! Form::close() !!}
+{{ html()->form()->close() }}

--- a/src/resources/views/forms/delete-full.blade.php
+++ b/src/resources/views/forms/delete-full.blade.php
@@ -1,13 +1,11 @@
-{!! Form::open([
-    'route' => ['laravelblocker::blocker.destroy', $item->id],
-    'method' => 'DELETE',
-    'accept-charset' => 'UTF-8',
-    'data-toggle' => 'tooltip',
-    'title' => trans('laravelblocker::laravelblocker.tooltips.delete')
-]) !!}
-    {!! Form::hidden("_method", "DELETE") !!}
-    {!! csrf_field() !!}
-    <button class="btn btn-danger btn-block edit-form-delete" type="button" style="width: 100%;" data-toggle="modal" data-target="#confirmDelete" data-title="{{ trans('laravelblocker::laravelblocker.modals.delete_blocked_title') }}" data-message="{!! trans("laravelblocker::laravelblocker.modals.delete_blocked_message", ["blocked" => $item->value]) !!}">
-        {!! trans("laravelblocker::laravelblocker.buttons.delete-larger") !!}
+{{ html()->form('POST', route('laravelblocker::blocker.destroy', $item->id))
+        ->attribute('accept-charset', 'UTF-8')
+        ->attribute('data-toggle', 'tooltip')
+        ->attribute('title', trans('laravelblocker::laravelblocker.tooltips.delete'))
+        ->open() }}
+    @csrf
+    @method('DELETE')
+    <button class="btn btn-danger btn-block edit-form-delete" type="button" style="width: 100%;" data-toggle="modal" data-target="#confirmDelete" data-title="{{ trans('laravelblocker::laravelblocker.modals.delete_blocked_title') }}" data-message="{!! trans('laravelblocker::laravelblocker.modals.delete_blocked_message', ['blocked' => $item->value]) !!}">
+        {!! trans('laravelblocker::laravelblocker.buttons.delete-larger') !!}
     </button>
-{!! Form::close() !!}
+{{ html()->form()->close() }}

--- a/src/resources/views/forms/delete-item.blade.php
+++ b/src/resources/views/forms/delete-item.blade.php
@@ -1,13 +1,11 @@
-{!! Form::open([
-    'route' => ['laravelblocker::blocker.destroy', $item->id],
-    'method' => 'DELETE',
-    'accept-charset' => 'UTF-8',
-    'data-toggle' => 'tooltip',
-    'title' => trans('laravelblocker::laravelblocker.tooltips.delete')
-]) !!}
-    {!! Form::hidden("_method", "DELETE") !!}
-    {!! csrf_field() !!}
-    <button class="btn btn-danger btn-sm" type="button" style="width: 100%;" data-toggle="modal" data-target="#confirmDelete" data-title="Delete Blocked Item" data-message="{!! trans("laravelblocker::laravelblocker.modals.delete_blocked_message", ["blocked" => $item->value]) !!}">
-        {!! trans("laravelblocker::laravelblocker.buttons.delete-larger") !!}
+{{ html()->form('POST', route('laravelblocker::blocker.destroy', $item->id))
+        ->attribute('accept-charset', 'UTF-8')
+        ->attribute('data-toggle', 'tooltip')
+        ->attribute('title', trans('laravelblocker::laravelblocker.tooltips.delete'))
+        ->open() }}
+    @csrf
+    @method('DELETE')
+    <button class="btn btn-danger btn-sm" type="button" style="width: 100%;" data-toggle="modal" data-target="#confirmDelete" data-title="Delete Blocked Item" data-message="{!! trans('laravelblocker::laravelblocker.modals.delete_blocked_message', ['blocked' => $item->value]) !!}">
+        {!! trans('laravelblocker::laravelblocker.buttons.delete-larger') !!}
     </button>
-{!! Form::close() !!}
+{{ html()->form()->close() }}

--- a/src/resources/views/forms/delete-sm.blade.php
+++ b/src/resources/views/forms/delete-sm.blade.php
@@ -1,13 +1,11 @@
-{!! Form::open([
-    'route' => ['laravelblocker::blocker.destroy', $blockedItem->id],
-    'method' => 'DELETE',
-    'accept-charset' => 'UTF-8',
-    'data-toggle' => 'tooltip',
-    'title' => trans('laravelblocker::laravelblocker.tooltips.delete')
-]) !!}
-    {!! Form::hidden("_method", "DELETE") !!}
-    {!! csrf_field() !!}
-    <button class="btn btn-danger btn-sm btn-block" type="button" style="width: 100%;" data-toggle="modal" data-target="#confirmDelete" data-title="Delete Blocked Item" data-message="{!! trans("laravelblocker::laravelblocker.modals.delete_blocked_message", ["blocked" => $blockedItem->value]) !!}">
-        {!! trans("laravelblocker::laravelblocker.buttons.delete") !!}
+{{ html()->form('POST', route('laravelblocker::blocker.destroy', $blockedItem->id))
+        ->attribute('accept-charset', 'UTF-8')
+        ->attribute('data-toggle', 'tooltip')
+        ->attribute('title', trans('laravelblocker::laravelblocker.tooltips.delete'))
+        ->open() }}
+    @csrf
+    @method('DELETE')
+    <button class="btn btn-danger btn-sm btn-block" type="button" style="width: 100%;" data-toggle="modal" data-target="#confirmDelete" data-title="Delete Blocked Item" data-message="{!! trans('laravelblocker::laravelblocker.modals.delete_blocked_message', ['blocked' => $blockedItem->value]) !!}">
+        {!! trans('laravelblocker::laravelblocker.buttons.delete') !!}
     </button>
-{!! Form::close() !!}
+{{ html()->form()->close() }}

--- a/src/resources/views/forms/destroy-all.blade.php
+++ b/src/resources/views/forms/destroy-all.blade.php
@@ -1,11 +1,9 @@
-{!! Form::open([
-    'route' => 'laravelblocker::destroy-all-blocked',
-    'method' => 'DELETE',
-    'accept-charset' => 'UTF-8'
-]) !!}
-    {!! Form::hidden("_method", "DELETE") !!}
-    {!! csrf_field() !!}
-    <button class="dropdown-item btn pointer" type="button" style="width: 100%;" data-toggle="modal" data-target="#confirmDelete" data-title="{{ trans('laravelblocker::laravelblocker.modals.destroy_all_blocked_title') }}" data-message="{!! trans("laravelblocker::laravelblocker.modals.destroy_all_blocked_message") !!}">
-        <i class="fa fa-trash fa-fw" aria-hidden="true"></i> {!! trans_choice("laravelblocker::laravelblocker.buttons.destroy-all", 1, ['count' => $blocked->count()]) !!}
+{{ html()->form('POST', route('laravelblocker::destroy-all-blocked'))
+        ->attribute('accept-charset', 'UTF-8')
+        ->open() }}
+    @csrf
+    @method('DELETE')
+    <button class="dropdown-item btn pointer" type="button" style="width: 100%;" data-toggle="modal" data-target="#confirmDelete" data-title="{{ trans('laravelblocker::laravelblocker.modals.destroy_all_blocked_title') }}" data-message="{!! trans('laravelblocker::laravelblocker.modals.destroy_all_blocked_message') !!}">
+        <i class="fa fa-trash fa-fw" aria-hidden="true"></i> {!! trans_choice('laravelblocker::laravelblocker.buttons.destroy-all', 1, ['count' => $blocked->count()]) !!}
     </button>
-{!! Form::close() !!}
+{{ html()->form()->close() }}

--- a/src/resources/views/forms/destroy-full.blade.php
+++ b/src/resources/views/forms/destroy-full.blade.php
@@ -1,13 +1,11 @@
-{!! Form::open([
-    'route' => ['laravelblocker::blocker-item-destroy', $item->id],
-    'method' => 'DELETE',
-    'accept-charset' => 'UTF-8',
-    'data-toggle' => 'tooltip',
-    'title' => trans("laravelblocker::laravelblocker.tooltips.destroy_blocked_tooltip")
-]) !!}
-    {!! Form::hidden("_method", "DELETE") !!}
-    {!! csrf_field() !!}
-    <button class="btn btn-danger btn-block edit-form-destroy" type="button" style="width: 100%;" data-toggle="modal" data-target="#confirmDelete" data-title="{{ trans('laravelblocker::laravelblocker.modals.destroy_blocked_title') }}" data-message="{!! trans("laravelblocker::laravelblocker.modals.destroy_blocked_message", ["blocked" => $item->value]) !!}">
-        {!! trans("laravelblocker::laravelblocker.buttons.destroy-larger") !!}
+{{ html()->form('POST', route('laravelblocker::blocker-item-destroy', $item->id))
+        ->attribute('accept-charset', 'UTF-8')
+        ->attribute('data-toggle', 'tooltip')
+        ->attribute('title', trans('laravelblocker::laravelblocker.tooltips.destroy_blocked_tooltip'))
+        ->open() }}
+    @csrf
+    @method('DELETE')
+    <button class="btn btn-danger btn-block edit-form-destroy" type="button" style="width: 100%;" data-toggle="modal" data-target="#confirmDelete" data-title="{{ trans('laravelblocker::laravelblocker.modals.destroy_blocked_title') }}" data-message="{!! trans('laravelblocker::laravelblocker.modals.destroy_blocked_message', ['blocked' => $item->value]) !!}">
+        {!! trans('laravelblocker::laravelblocker.buttons.destroy-larger') !!}
     </button>
-{!! Form::close() !!}
+{{ html()->form()->close() }}

--- a/src/resources/views/forms/destroy-sm.blade.php
+++ b/src/resources/views/forms/destroy-sm.blade.php
@@ -1,13 +1,11 @@
-{!! Form::open([
-    'route' => ['laravelblocker::blocker-item-destroy', $blockedItem->id],
-    'method' => 'DELETE',
-    'accept-charset' => 'UTF-8',
-    'data-toggle' => 'tooltip',
-    'title' => trans("laravelblocker::laravelblocker.tooltips.destroy_blocked_tooltip")
-]) !!}
-    {!! Form::hidden("_method", "DELETE") !!}
-    {!! csrf_field() !!}
-    <button class="btn btn-danger btn-sm" type="button" style="width: 100%;" data-toggle="modal" data-target="#confirmDelete" data-title="{{ trans("laravelblocker::laravelblocker.modals.destroy_blocked_title") }}" data-message="{!! trans("laravelblocker::laravelblocker.modals.destroy_blocked_message", ["blocked" => $blockedItem->value]) !!}">
-        {!! trans("laravelblocker::laravelblocker.buttons.destroy") !!}
+{{ html()->form('POST', route('laravelblocker::blocker-item-destroy', $blockedItem->id))
+        ->attribute('accept-charset', 'UTF-8')
+        ->attribute('data-toggle', 'tooltip')
+        ->attribute('title', trans('laravelblocker::laravelblocker.tooltips.destroy_blocked_tooltip'))
+        ->open() }}
+    @csrf
+    @method('DELETE')
+    <button class="btn btn-danger btn-sm" type="button" style="width: 100%;" data-toggle="modal" data-target="#confirmDelete" data-title="{{ trans('laravelblocker::laravelblocker.modals.destroy_blocked_title') }}" data-message="{!! trans('laravelblocker::laravelblocker.modals.destroy_blocked_message', ['blocked' => $blockedItem->value]) !!}">
+        {!! trans('laravelblocker::laravelblocker.buttons.destroy') !!}
     </button>
-{!! Form::close() !!}
+{{ html()->form()->close() }}

--- a/src/resources/views/forms/edit-form.blade.php
+++ b/src/resources/views/forms/edit-form.blade.php
@@ -1,20 +1,21 @@
-{!! Form::open([
-    'route' => ['laravelblocker::blocker.update', $item->id],
-    'method' => 'PUT',
-    'role' => 'form',
-    'class' => 'needs-validation'
-]) !!}
-    {!! csrf_field() !!}
+{{ html()->form('POST', route('laravelblocker::blocker.update', $item->id))
+        ->attribute('role', 'form')
+        ->class('needs-validation')
+        ->open() }}
+    @csrf
+    @method('PUT')
     @include('laravelblocker::forms.partials.item-type-select')
     @include('laravelblocker::forms.partials.item-value-input')
     @include('laravelblocker::forms.partials.item-blocked-user-select')
     @include('laravelblocker::forms.partials.item-note-input')
     <div class="row">
         <div class="col-sm-6 offset-sm-6 mt-1">
-            {!! Form::button(trans('laravelblocker::laravelblocker.buttons.save-larger'), array('class' => 'btn btn-success btn-block margin-bottom-1 mb-1 float-right','type' => 'submit' )) !!}
+            {{ html()->button(trans('laravelblocker::laravelblocker.buttons.save-larger'))
+                    ->class('btn btn-success btn-block margin-bottom-1 mb-1 float-right')
+                    ->type('submit') }}
         </div>
     </div>
-{!! Form::close() !!}
+{{ html()->form()->close() }}
 <div class="row">
     <div class="col-sm-6 mt-2 mt-sm-0">
         @include('laravelblocker::forms.delete-full')

--- a/src/resources/views/forms/partials/item-blocked-user-select.blade.php
+++ b/src/resources/views/forms/partials/item-blocked-user-select.blade.php
@@ -1,5 +1,5 @@
 <div class="form-group has-feedback row">
-    {!! Form::label('userId', trans('laravelblocker::laravelblocker.forms.blockedUserLabel'), array('class' => 'col-md-3 control-label disabled', 'id' => 'blockerUserLabel1')); !!}
+    {{ html()->label('userId', trans('laravelblocker::laravelblocker.forms.blockedUserLabel'))->class('col-md-3 control-label disabled')->id('blockerUserLabel1') }}
     <div class="col-md-9">
         <div class="input-group">
             <select class="{{ $errors->has('userId') ? 'custom-select form-control is-invalid disabled' : 'custom-select form-control disabled' }}" name="userId" id="userId">

--- a/src/resources/views/forms/partials/item-note-input.blade.php
+++ b/src/resources/views/forms/partials/item-note-input.blade.php
@@ -1,11 +1,18 @@
 <div class="form-group has-feedback row">
-    {!! Form::label('note', trans('laravelblocker::laravelblocker.forms.blockedNoteLabel'), array('class' => 'col-md-3 control-label')); !!}
+    {{ html()->label('note', trans('laravelblocker::laravelblocker.forms.blockedNoteLabel'))->class('col-md-3 control-label') }}
     <div class="col-md-9">
         <div class="input-group">
+            @php($noteInputClass = $errors->has('note') ? 'form-control is-invalid' : 'form-control')
             @isset($item)
-                {!! Form::textarea('note', $item->note, array('id' => 'note', 'class' => $errors->has('note') ? 'form-control is-invalid ' : 'form-control', 'placeholder' => trans('laravelblocker::laravelblocker.forms.blockedNotePH'))) !!}
+                {{ html()->textarea('note', old('note', $item->note))
+                        ->id('note')
+                        ->class($noteInputClass)
+                        ->attribute('placeholder', trans('laravelblocker::laravelblocker.forms.blockedNotePH')) }}
             @else
-                {!! Form::textarea('note', NULL, array('id' => 'note', 'class' => $errors->has('note') ? 'form-control is-invalid ' : 'form-control', 'placeholder' => trans('laravelblocker::laravelblocker.forms.blockedNotePH'))) !!}
+                {{ html()->textarea('note', old('note'))
+                        ->id('note')
+                        ->class($noteInputClass)
+                        ->attribute('placeholder', trans('laravelblocker::laravelblocker.forms.blockedNotePH')) }}
             @endisset
             <div class="input-group-append">
                 <label class="input-group-text" for="note">

--- a/src/resources/views/forms/partials/item-type-select.blade.php
+++ b/src/resources/views/forms/partials/item-type-select.blade.php
@@ -1,5 +1,5 @@
 <div class="form-group has-feedback row">
-    {!! Form::label('typeId', trans('laravelblocker::laravelblocker.forms.blockedTypeLabel'), array('class' => 'col-md-3 control-label')); !!}
+    {{ html()->label('typeId', trans('laravelblocker::laravelblocker.forms.blockedTypeLabel'))->class('col-md-3 control-label') }}
     <div class="col-md-9">
         <div class="input-group">
             <select class="{{ $errors->has('typeId') ? 'custom-select form-control is-invalid ' : 'custom-select form-control' }}" name="typeId" id="typeId" >

--- a/src/resources/views/forms/partials/item-value-input.blade.php
+++ b/src/resources/views/forms/partials/item-value-input.blade.php
@@ -1,11 +1,18 @@
 <div class="form-group has-feedback row">
-    {!! Form::label('value', trans('laravelblocker::laravelblocker.forms.blockedValueLabel'), array('class' => 'col-md-3 control-label', 'id' => 'blockerValueLabel1')); !!}
+    {{ html()->label('value', trans('laravelblocker::laravelblocker.forms.blockedValueLabel'))->class('col-md-3 control-label')->id('blockerValueLabel1') }}
     <div class="col-md-9">
         <div class="input-group">
+            @php($valueInputClass = $errors->has('value') ? 'form-control is-invalid' : 'form-control')
             @isset($item)
-                {!! Form::text('value', $item->value, array('id' => 'value', 'class' => $errors->has('value') ? 'form-control is-invalid ' : 'form-control', 'placeholder' => trans('laravelblocker::laravelblocker.forms.blockedValuePH'))) !!}
+                {{ html()->text('value', old('value', $item->value))
+                        ->id('value')
+                        ->class($valueInputClass)
+                        ->attribute('placeholder', trans('laravelblocker::laravelblocker.forms.blockedValuePH')) }}
             @else
-                {!! Form::text('value', NULL, array('id' => 'value', 'class' => $errors->has('value') ? 'form-control is-invalid ' : 'form-control', 'placeholder' => trans('laravelblocker::laravelblocker.forms.blockedValuePH'))) !!}
+                {{ html()->text('value', old('value'))
+                        ->id('value')
+                        ->class($valueInputClass)
+                        ->attribute('placeholder', trans('laravelblocker::laravelblocker.forms.blockedValuePH')) }}
             @endisset
             <div class="input-group-append">
                 <label class="input-group-text" for="value" id="blockerValueLabel2">

--- a/src/resources/views/forms/restore-all.blade.php
+++ b/src/resources/views/forms/restore-all.blade.php
@@ -1,17 +1,13 @@
-{!! Form::open([
-    'route' => 'laravelblocker::blocker-deleted-restore-all',
-    'method' => 'POST',
-    'accept-charset' => 'UTF-8'
-]) !!}
-    {!! csrf_field() !!}
-    {!! Form::button('
-        <i class="fa fa-fw fa-history" aria-hidden="true"></i> ' . trans_choice('laravelblocker::laravelblocker.buttons.restore-all-blocked', 1, ['count' => $blocked->count()]),
-        [
-            'type' => 'button',
-            'class' => 'btn dropdown-item',
-            'data-toggle' => 'modal',
-            'data-target' => '#confirmRestore',
-            'data-title' => trans('laravelblocker::laravelblocker.modals.resotreAllBlockedTitle'),
-            'data-message' => trans('laravelblocker::laravelblocker.modals.resotreAllBlockedMessage')
-        ]) !!}
-{!! Form::close() !!}
+{{ html()->form('POST', route('laravelblocker::blocker-deleted-restore-all'))
+        ->attribute('accept-charset', 'UTF-8')
+        ->open() }}
+    @csrf
+    {{ html()->button()->type('button')
+            ->class('btn dropdown-item')
+            ->attribute('data-toggle', 'modal')
+            ->attribute('data-target', '#confirmRestore')
+            ->attribute('data-title', trans('laravelblocker::laravelblocker.modals.resotreAllBlockedTitle'))
+            ->attribute('data-message', trans('laravelblocker::laravelblocker.modals.resotreAllBlockedMessage'))
+            ->html('<i class="fa fa-fw fa-history" aria-hidden="true"></i> ' .
+                trans_choice('laravelblocker::laravelblocker.buttons.restore-all-blocked', 1, ['count' => $blocked->count()])) }}
+{{ html()->form()->close() }}

--- a/src/resources/views/forms/restore-item.blade.php
+++ b/src/resources/views/forms/restore-item.blade.php
@@ -15,21 +15,18 @@
     @endphp
 @endif
 
-{!! Form::open([
-    'route' => ['laravelblocker::blocker-item-restore', $itemId],
-    'method' => 'PUT',
-    'accept-charset' => 'UTF-8',
-    'data-toggle' => 'tooltip',
-    'title' => trans("laravelblocker::laravelblocker.tooltips.restoreItem")
-]) !!}
-    {!! Form::hidden("_method", "PUT") !!}
-    {!! csrf_field() !!}
-    {!! Form::button($itemText, [
-            'type' => 'button',
-            'class' => $itemClasses,
-            'data-toggle' => 'modal',
-            'data-target' => '#confirmRestore',
-            'data-title' => trans('laravelblocker::laravelblocker.modals.resotreBlockedItemTitle'),
-            'data-message' => trans('laravelblocker::laravelblocker.modals.resotreBlockedItemMessage', ['value' => $itemValue])
-        ]) !!}
-{!! Form::close() !!}
+{{ html()->form('POST', route('laravelblocker::blocker-item-restore', $itemId))
+        ->attribute('accept-charset', 'UTF-8')
+        ->attribute('data-toggle', 'tooltip')
+        ->attribute('title', trans('laravelblocker::laravelblocker.tooltips.restoreItem'))
+        ->open() }}
+    @csrf
+    @method('PUT')
+    {{ html()->button($itemText)
+            ->type('button')
+            ->class($itemClasses)
+            ->attribute('data-toggle', 'modal')
+            ->attribute('data-target', '#confirmRestore')
+            ->attribute('data-title', trans('laravelblocker::laravelblocker.modals.resotreBlockedItemTitle'))
+            ->attribute('data-message', trans('laravelblocker::laravelblocker.modals.resotreBlockedItemMessage', ['value' => $itemValue])) }}
+{{ html()->form()->close() }}

--- a/src/resources/views/forms/search-blocked.blade.php
+++ b/src/resources/views/forms/search-blocked.blade.php
@@ -1,15 +1,17 @@
 <div class="row" id="search_blocked_form">
     <div class="col-sm-8 offset-sm-4 col-md-6 offset-md-6 col-lg-5 offset-lg-7 col-xl-4 offset-xl-8">
-        {!! Form::open([
-            'route' => 'laravelblocker::search-blocked',
-            'method' => 'POST',
-            'role' => 'form',
-            'class' => 'needs-validation',
-            'id' => 'search_blocked'
-        ]) !!}
-            {!! csrf_field() !!}
+        {{ html()->form('POST', route('laravelblocker::search-blocked'))
+                ->attribute('role', 'form')
+                ->class('needs-validation')
+                ->id('search_blocked')
+                ->open() }}
+            @csrf
             <div class="input-group mb-3">
-                {!! Form::text('blocked_search_box', NULL, ['id' => 'blocked_search_box', 'class' => 'form-control', 'placeholder' => trans('laravelblocker::laravelblocker.forms.search-blocked-ph'), 'aria-label' => trans('laravelblocker::forms.search-users-ph'), 'required' => false]) !!}
+                {{ html()->text('blocked_search_box')
+                        ->id('blocked_search_box')
+                        ->class('form-control')
+                        ->attribute('placeholder', trans('laravelblocker::laravelblocker.forms.search-blocked-ph'))
+                        ->attribute('aria-label', trans('laravelblocker::forms.search-users-ph')) }}
                 <div class="input-group-append">
                     <a href="#" class="btn btn-warning clear-search" style="display: none;" data-toggle="tooltip" title="{!! trans('laravelblocker::laravelblocker.tooltips.clear-search') !!}">
                         @if(config('laravelblocker.blockerEnableFontAwesomeCDN'))
@@ -24,12 +26,21 @@
                         @endif
                     </a>
                     @if(config('laravelblocker.blockerEnableFontAwesomeCDN'))
-                        {!! Form::button('<i class="fa fas fa-search" aria-hidden="true"></i> <span class="sr-only"> ' . trans('laravelblocker::laravelblocker.tooltips.submit-search') . ' </span>', ['class' => 'btn btn-secondary', 'type' => 'submit', 'data-toggle' => 'tooltip', 'data-placement' => 'bottom', 'title' => trans('laravelblocker::laravelblocker.tooltips.submit-search')]) !!}
+                        {{ html()->button()
+                                ->class('btn btn-secondary')
+                                ->type('submit')
+                                ->attribute('data-toggle', 'tooltip')
+                                ->attribute('data-placement', 'bottom')
+                                ->attribute('title', trans('laravelblocker::laravelblocker.tooltips.submit-search'))
+                                ->html('<i class="fa fas fa-search" aria-hidden="true"></i> <span class="sr-only"> ' . trans('laravelblocker::laravelblocker.tooltips.submit-search') . ' </span>') }}
                     @else
-                        {!! Form::button(trans('laravelblocker::laravelblocker.tooltips.submit-search'), ['class' => 'btn btn-secondary', 'type' => 'submit', 'title' => trans('laravelblocker::laravelblocker.tooltips.submit-search')]) !!}
+                        {{ html()->button(trans('laravelblocker::laravelblocker.tooltips.submit-search'))
+                                ->class('btn btn-secondary')
+                                ->type('submit')
+                                ->attribute('title', trans('laravelblocker::laravelblocker.tooltips.submit-search')) }}
                     @endif
                 </div>
             </div>
-        {!! Form::close() !!}
+        {{ html()->form()->close() }}
     </div>
 </div>

--- a/src/resources/views/modals/confirm-modal.blade.php
+++ b/src/resources/views/modals/confirm-modal.blade.php
@@ -26,8 +26,16 @@
                 </p>
             </div>
             <div class="modal-footer">
-                {!! Form::button('<i class="fa fa-fw fa-close" aria-hidden="true"></i> ' . trans('laravelblocker::laravelblocker.modals.btnCancel'), array('class' => 'btn btn-outline pull-left btn-flat', 'type' => 'button', 'data-dismiss' => 'modal' )) !!}
-                {!! Form::button('<i class="fa ' . $actionBtnIcon . '" aria-hidden="true"></i> ' . $btnSubmitText, array('class' => 'btn btn-' . $modalClass . ' pull-right btn-flat', 'type' => 'button', 'id' => 'confirm' )) !!}
+                {{ html()->button()
+                        ->class('btn btn-outline pull-left btn-flat')
+                        ->type('button')
+                        ->attribute('data-dismiss', 'modal')
+                        ->html('<i class="fa fa-fw fa-close" aria-hidden="true"></i> ' . trans('laravelblocker::laravelblocker.modals.btnCancel')) }}
+                {{ html()->button()
+                        ->class('btn btn-' . $modalClass . ' pull-right btn-flat')
+                        ->type('button')
+                        ->id('confirm')
+                        ->html('<i class="fa ' . $actionBtnIcon . '" aria-hidden="true"></i> ' . $btnSubmitText) }}
             </div>
         </div>
     </div>

--- a/src/resources/views/scripts/search-blocked.blade.php
+++ b/src/resources/views/scripts/search-blocked.blade.php
@@ -58,8 +58,8 @@
                                 var showCellHtml = '<a class="btn btn-sm btn-success btn-block" href="blocker/' + val.id + '" data-toggle="tooltip" title="{{ trans("laravelblocker::laravelblocker.tooltips.show") }}">{!! trans("laravelblocker::laravelblocker.buttons.show") !!}</a>';
                                 var editCellHtml = '<a class="btn btn-sm btn-info btn-block" href="blocker/' + val.id + '/edit" data-toggle="tooltip" title="{{ trans("laravelblocker::laravelblocker.tooltips.edit") }}">{!! trans("laravelblocker::laravelblocker.buttons.edit") !!}</a>';
                                 var deleteCellHtml = '<form method="POST" action="/blocker/'+ val.id +'" accept-charset="UTF-8" data-toggle="tooltip" title="Delete Blocked Item">' +
-                                        '{!! Form::hidden("_method", "DELETE") !!}' +
-                                        '{!! csrf_field() !!}' +
+                                        '{{ html()->hidden("_method", "DELETE") }}' +
+                                        '{{ csrf_field() }}' +
                                         '<button class="btn btn-danger btn-sm" type="button" style="width: 100%;" data-toggle="modal" data-target="#confirmDelete" data-title="Delete Blocked Item" data-message="{!! trans("laravelblocker::laravelblocker.modals.delete_blocked_message", ["blocked" => "'+val.name+'"]) !!}">' +
                                             '{!! trans("laravelblocker::laravelblocker.buttons.delete") !!}' +
                                         '</button>' +


### PR DESCRIPTION
## Summary
- replace the LaravelCollective dependency with spatie/laravel-html
- refactor all Blade forms and modal controls to use the html() builder with explicit CSRF and method directives
- update the README to describe the new HTML helper package setup

## Testing
- vendor/bin/phpunit *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c91ef4c7f4832a95657e0549d42852